### PR TITLE
[#54920] GH Actions: Changed base CI container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ on:
 jobs:
     readme-tests:
         runs-on: ubuntu-latest
+        container:
+            image: debian:bullseye
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
-              with:
-                  submodules: 'recursive'
             - name: Install tuttest dependencies
               run: |
-                  sudo apt-get update -qqy
-                  sudo apt-get install -qqy --no-install-recommends python3 python3-pip git colorized-logs
+                  apt-get update -qqy
+                  apt-get install -qqy --no-install-recommends python3 python3-pip git colorized-logs sudo
                   sudo pip3 install git+https://github.com/antmicro/tuttest.git
             - name: Run README.md snippets
               run: |


### PR DESCRIPTION
This PR changes the base image for GH Actions execution in order to use a `mono-complete` version compatible with the simulation.