### PR TITLE
[#66667] GHA: tuttest: Updated image to debian:bookworm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     readme-tests:
         runs-on: ubuntu-latest
         container:
-            image: debian:bullseye
+            image: debian:bookworm
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -18,7 +18,7 @@ jobs:
               run: |
                   apt-get update -qqy
                   apt-get install -qqy --no-install-recommends python3 python3-pip git colorized-logs sudo
-                  sudo pip3 install git+https://github.com/antmicro/tuttest.git
+                  sudo pip3 install --break-system-packages git+https://github.com/antmicro/tuttest.git
             - name: Run README.md snippets
               run: |
                   ./scripts/test_readme.sh

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ To be able to build and use the project, you need the folowing dependencies:
 * `jq`
 * `curl`
 * `west`
+* `patch`
 * `CMake`
 
 On Debian-based Linux distributions, install the dependencies as follows:
@@ -105,7 +106,7 @@ sudo apt update
 sudo apt install -y --no-install-recommends ccache curl device-tree-compiler dfu-util file \
   g++-multilib gcc gcc-multilib git jq libmagic1 libsdl2-dev make ninja-build \
   python3-dev python3-pip python3-setuptools python3-tk python3-wheel python3-venv \
-  mono-complete wget xxd xz-utils
+  mono-complete wget xxd xz-utils patch
 ```
 
 ### Cloning the project and preparing the environment


### PR DESCRIPTION
This PR updates Docker image used to test the project to `debian:bookworm`